### PR TITLE
fix: never resolving native calls

### DIFF
--- a/android/src/main/java/com/example/volume/VolumePlugin.java
+++ b/android/src/main/java/com/example/volume/VolumePlugin.java
@@ -77,6 +77,7 @@ public class VolumePlugin implements FlutterPlugin, ActivityAware, MethodCallHan
             int i = call.argument("streamType");
             streamType = i;
             controlVolume(i);
+            result.success(null);
         } else if (call.method.equals("getMaxVol")) {
             result.success(getMaxVol());
         } else if (call.method.equals("getVol")) {
@@ -84,6 +85,7 @@ public class VolumePlugin implements FlutterPlugin, ActivityAware, MethodCallHan
         } else if (call.method.equals("setVol")) {
             int i = call.argument("newVol");
             setVol(i);
+            result.success(0);
         } else {
             result.notImplemented();
         }


### PR DESCRIPTION
As outlined in https://github.com/Aman-Malhotra/Volume_Flutter/issues/5, there are two `result.success` calls missing causing the Futures of `setVolume` and `controlVolume` to never resolve.

Making the PR here because the original repo is stale for over a year now and I have switched to this repo as source for the package :)